### PR TITLE
DPI-2937 Package rhtmlEchoLifecycle in nix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,7 @@ Version: 1.0.0
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: An HTML widget that echoes all functon calls for debug purposes.
+Imports: htmlwidgets
 License: GPL-3
 LazyData: TRUE
 RoxygenNote: 7.1.1

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "rhtmlEchoLifecycle";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''An HTML widget that echoes all functon calls for debug purposes.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    htmlwidgets
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package rhtmlEchoLifecycle in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR